### PR TITLE
update strip_handshake f(n)

### DIFF
--- a/wifite.py
+++ b/wifite.py
@@ -2459,7 +2459,11 @@ class WPAAttack(Attack):
                    'stripLive']
             call(cmd, stdout=DN, stderr=DN)
             if os.path.exists(capfile + '.temp'):
-                rename(capfile + '.temp', output_file)
+
+                ###robsouth84 update###
+                ###orig###rename(capfile + '.temp', output_file)
+                copy(output_file, capfile + '.temp')
+
 
         elif program_exists('tshark'):
             # strip results with tshark
@@ -2470,7 +2474,9 @@ class WPAAttack(Attack):
                    '-w', capfile + '.temp']  # output file
             proc_strip = call(cmd, stdout=DN, stderr=DN)
 
-            rename(capfile + '.temp', output_file)
+            ###robsouth84 update###
+            ###orig###rename(capfile + '.temp', output_file)
+            copy(output_file, capfile + '.temp')
 
         else:
             print R + " [!]" + O + " unable to strip .cap file: neither pyrit nor tshark were found" + W


### PR DESCRIPTION
rename command was incorrect and was throwing an error when trying to crack a handshake.
It was attempting to move a non existent file when I believe it intended to copy an existing file to the location of the non existent file
confirmed to find and crack handshake on my test lab

 [+] starting WPA cracker on 1 handshake
 [0:00:00] cracking <test SSID> with aircrack-ng
['aircrack-ng', '-a', '2', '-w', 'rockyou.txt', '-l', '/tmp/<random dir>/wpakey.txt', '-b', '<test MAC>', 'hs/<test SSID>_<test MAC>.cap']
 [+] cracked <test SSID> (<test MAC>)!
 [+] key:    "12345678"
 [+] quitting